### PR TITLE
v1.13.1 — Bug fixes: CSS, memory leak, dead code, ID collisions

### DIFF
--- a/components/CustomLabelsManager.tsx
+++ b/components/CustomLabelsManager.tsx
@@ -59,7 +59,7 @@ export const CustomLabelsManager: React.FC<CustomLabelsManagerProps> = ({ profil
       } else {
         // Add new
         const newLabel: CustomLabel = {
-          id: `cl-${Date.now()}`,
+          id: crypto.randomUUID(),
           name: name.trim(),
           labels: associatedLabels
         };

--- a/components/PhotoContent.tsx
+++ b/components/PhotoContent.tsx
@@ -29,7 +29,7 @@ const PhotoGrid: React.FC<PhotoGridProps> = ({ photos, onSelectPhoto, onViewPhot
     S: 'grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 2xl:grid-cols-10',
     M: 'grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-8',
     L: 'grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6',
-    XL: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl-grid-cols-5',
+    XL: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5',
   };
 
   return (

--- a/components/RulesManager.tsx
+++ b/components/RulesManager.tsx
@@ -27,7 +27,7 @@ export const RulesManager: React.FC<RulesManagerProps> = ({ profile, setProfile,
     if (type === 'classification') {
       if (!newClassificationRule.label.trim()) return;
       const ruleToAdd: FilterRule = {
-        id: Date.now().toString(),
+        id: crypto.randomUUID(),
         label: newClassificationRule.label.trim(),
       };
       if (!isClassificationAnyConfidence) {
@@ -42,7 +42,7 @@ export const RulesManager: React.FC<RulesManagerProps> = ({ profile, setProfile,
     } else {
       if (!newDetectionRule.label.trim()) return;
       const ruleToAdd: FilterRule = {
-        id: Date.now().toString(),
+        id: crypto.randomUUID(),
         label: newDetectionRule.label.trim(),
       };
       if (!isDetectionAnyConfidence) {

--- a/hooks/useFileSystem.ts
+++ b/hooks/useFileSystem.ts
@@ -90,6 +90,11 @@ export const useFileSystem = (
 
       setStatusMessage(`Found ${filesToProcess.length} photos. Queuing for analysis...`);
 
+      // Revoke old blob URLs to prevent memory leak
+      for (const photo of photos.values()) {
+        URL.revokeObjectURL(photo.objectURL);
+      }
+
       const tempPhotosMap = new Map<string, Photo>();
       // Use Promise.all to speed up file reading for previews
       await Promise.all(filesToProcess.map(async ({ path, handle }) => {
@@ -97,7 +102,6 @@ export const useFileSystem = (
         const objectURL = URL.createObjectURL(file);
         tempPhotosMap.set(path, {
           id: path,
-          binary: '', // Will be loaded on demand for analysis
           objectURL,
           status: PhotoStatus.QUEUED,
           classifications: [],

--- a/hooks/usePhotoManager.ts
+++ b/hooks/usePhotoManager.ts
@@ -343,7 +343,7 @@ export const usePhotoManager = ({ userProfile, onProfileUpdate, filterLabel }: U
         const topClassification = photo.classifications.reduce((max, p) => p.score > max.score ? p : max);
         if (!existingClassificationLabels.has(topClassification.label.toLowerCase())) {
           newClassificationRules.push({
-            id: `${Date.now()}-c-${topClassification.label}`,
+            id: crypto.randomUUID(),
             label: topClassification.label,
             confidence: Math.max(1, Math.floor(topClassification.score * 100)),
           });
@@ -353,7 +353,7 @@ export const usePhotoManager = ({ userProfile, onProfileUpdate, filterLabel }: U
         const topDetection = photo.detections.reduce((max, p) => p.score > max.score ? p : max);
         if (!existingDetectionLabels.has(topDetection.label.toLowerCase())) {
           newDetectionRules.push({
-            id: `${Date.now()}-d-${topDetection.label}`,
+            id: crypto.randomUUID(),
             label: topDetection.label,
             confidence: Math.max(1, Math.floor(topDetection.score * 100)),
           });
@@ -390,7 +390,7 @@ export const usePhotoManager = ({ userProfile, onProfileUpdate, filterLabel }: U
       for (const [labelKey, data] of commonClassifications.entries()) {
         if (!existingClassificationLabels.has(labelKey)) {
           newClassificationRules.push({
-            id: `${Date.now()}-c-${labelKey}`,
+            id: crypto.randomUUID(),
             label: data.originalLabel,
             confidence: Math.max(1, Math.floor(data.score * 100)),
           });
@@ -399,7 +399,7 @@ export const usePhotoManager = ({ userProfile, onProfileUpdate, filterLabel }: U
       for (const [labelKey, data] of commonDetections.entries()) {
         if (!existingDetectionLabels.has(labelKey)) {
           newDetectionRules.push({
-            id: `${Date.now()}-d-${labelKey}`,
+            id: crypto.randomUUID(),
             label: data.originalLabel,
             confidence: Math.max(1, Math.floor(data.score * 100)),
           });
@@ -433,13 +433,13 @@ export const usePhotoManager = ({ userProfile, onProfileUpdate, filterLabel }: U
 
     const hasClassificationRule = currentProfile.classificationRules.some(r => r.label.toLowerCase() === lowercasedLabel);
     if (!hasClassificationRule) {
-      newProfile.classificationRules.push({ id: `${Date.now()}-c-${trimmedLabel}`, label: trimmedLabel });
+      newProfile.classificationRules.push({ id: crypto.randomUUID(), label: trimmedLabel });
       ruleAdded = true;
     }
 
     const hasDetectionRule = currentProfile.detectionRules.some(r => r.label.toLowerCase() === lowercasedLabel);
     if (!hasDetectionRule) {
-      newProfile.detectionRules.push({ id: `${Date.now()}-d-${trimmedLabel}`, label: trimmedLabel });
+      newProfile.detectionRules.push({ id: crypto.randomUUID(), label: trimmedLabel });
       ruleAdded = true;
     }
 

--- a/improvements.md
+++ b/improvements.md
@@ -1,0 +1,87 @@
+# Improvements — Pixo
+
+This document catalogs technical debt, performance opportunities, and feature ideas
+identified during code review. They are **not** bugs — the application works correctly
+as-is. These are refinements for future iterations.
+
+---
+
+## Performance
+
+### Virtual Scrolling (react-window / @tanstack/virtual)
+**Why:** With 1000+ photos, the DOM builds 1000+ nodes. Scroll and layout become sluggish.
+The grid view renders every photo unconditionally.
+**How:** Replace the flat `.map()` in `PhotoGrid` with a virtualized list that only
+renders visible + overscan nodes.
+
+### Web Worker for TensorFlow.js
+**Why:** `classifyImage`, `detectObjects`, `generateEmbedding`, and `detectBlur` all run
+on the main thread. While each call is fast, a batch of 100 photos can freeze the UI
+for several seconds.
+**How:** Offload TF.js work to a dedicated Web Worker. Serialize data URLs to the
+worker, receive predictions back via `postMessage`.
+
+### Thumbnail Cache (IndexedDB)
+**Why:** Every directory load re-creates blob URLs from scratch. Returning to a
+previously-opened folder re-analyzes thumbnails.
+**How:** Store `objectURL` → `blob` mappings in IndexedDB. On reload, check cache
+before fetching + creating new blob URLs.
+
+### Revoke Blob URLs on Unmount
+**Why:** The app creates `URL.createObjectURL()` for every photo but never revokes them
+on component unmount. Switching directories leaks memory until the tab is closed.
+**How:** Collect all active objectURLs in a `Set` and call `URL.revokeObjectURL()` in a
+`useEffect` cleanup or when loading a new directory.
+
+---
+
+## Code Quality
+
+### Merge Duplicate `useEffect` in PhotoCard
+**Why:** `PhotoCard.tsx` has two separate `useEffect` blocks — one for
+`IntersectionObserver` (lazy loading), another for click-timeout cleanup. They can
+share a single `useEffect` return for cleanup.
+
+### Reduce `useCallback` Wrapping
+**Why:** Several hooks wrap trivial event handlers in `useCallback` with large
+dependency arrays. The memoization cost sometimes exceeds the rerender cost.
+**How:** Profile with React DevTools; inline handlers that don't benefit from
+referential stability.
+
+### Type-Safe `(window as any).showDirectoryPicker`
+**Why:** The code casts `window` to `any` to access File System API. TypeScript
+doesn't know about these APIs yet (they are experimental).
+**How:** Declare an ambient type module (`.d.ts`) for the File System Access API
+instead of casting everywhere. Keep it minimal — only the methods used.
+
+---
+
+## Features (Future)
+
+| Priority | Feature | Rationale |
+|----------|---------|-----------|
+| Medium | **EXIF Metadata** | Parse date, camera, GPS → enable timeline filters, map view |
+| Medium | **Undo / Trash** | Current delete is permanent. Soft-delete with 30-day trash reduces accidents |
+| Low | **Video Support** | Accept `.mp4`, `.mov`, `.avi`. Extract first frame as thumbnail |
+| Low | **Export CSV** | Allow users to download a spreadsheet of photo locations, predictions, scores |
+| Low | **Keyboard Shortcuts** | Global hotkeys for Select All, Delete, Toggle Save, etc. (currently only in Zen Mode) |
+| Low | **Global i18n** | French, German, Spanish locale files. The UI is fully in English |
+| Low | **Photo Rating (1-5)** | Beyond the binary heart/saved toggle |
+
+---
+
+## Build & Tooling
+
+### PostCSS Tailwind (replace CDN)
+**Why:** `index.html` loads `cdn.tailwindcss.com` at runtime (~100 KB gzip). The
+production build includes the CDN script as-is. Switching to Vite + PostCSS +
+`@tailwindcss/vite` would eliminate the runtime dependency and shrink the bundle.
+
+### Stable React Version in Import Map
+**Why:** The import map points to `esm.sh/react@19.0.0-rc.0`. The npm package.json
+depends on `^19.1.0` (stable). Builds use the npm version, but the import map can
+cause confusion.
+
+### Remove `@types/node` Dev Dependency
+**Why:** The project does not use Node.js APIs. `@types/node` is installed but never
+imported.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-photo-sorter",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/duplicateDetection.ts
+++ b/services/duplicateDetection.ts
@@ -1,5 +1,5 @@
 
-import { Photo, DuplicateGroup } from './types.ts';
+import { Photo, DuplicateGroup, PhotoStatus } from './types.js';
 import { getTF } from './api.ts';
 
 // Similarity threshold for considering two photos as duplicates
@@ -7,7 +7,7 @@ import { getTF } from './api.ts';
 const DUPLICATE_THRESHOLD = 0.94;
 
 export const findDuplicateGroups = async (photos: Photo[]): Promise<DuplicateGroup[]> => {
-  const analyzedPhotos = photos.filter(p => p.status === 'ANALYZED' && p.embedding && p.embedding.length > 0);
+  const analyzedPhotos = photos.filter(p => p.status === PhotoStatus.ANALYZED && p.embedding && p.embedding.length > 0);
 
   if (analyzedPhotos.length < 2) return [];
 
@@ -109,7 +109,7 @@ function createDuplicateGroup(photoIds: string[], allPhotos: Photo[]): Duplicate
   });
 
   return {
-    id: `dup-group-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    id: crypto.randomUUID(),
     photos: photoIds,
     bestPhotoId: groupPhotos[0].id
   };

--- a/services/types.ts
+++ b/services/types.ts
@@ -14,7 +14,6 @@ export interface Prediction {
 
 export interface Photo {
   id: string; // The full path of the photo, used as a unique ID
-  binary: string; // base64 encoded string
   objectURL: string; // blob url for efficient rendering
   status: PhotoStatus;
   classifications: Prediction[];


### PR DESCRIPTION
## Bugs corrigés

### CSS
- **PhotoContent.tsx** — classe invalide `2xl-grid-cols-5` corrigée en `2xl:grid-cols-5`. La grille XL ne passait pas en 5 colonnes.

### Code mort
- **Photo interface** — champ `binary: string` supprimé. Toujours `''` en pratique, jamais utilisé. ~50 octets de mémoire par photo économisés.

### Enum string fragile
- **duplicateDetection.ts** — `p.status === 'ANALYZED'` remplacé par `PhotoStatus.ANALYZED`. Cassait si l'enum changeait.

### Collision d'IDs
- **8 occurrences de `Date.now()`** remplacées par `crypto.randomUUID()` dans RulesManager, CustomLabelsManager, usePhotoManager, duplicateDetection. Élimine le risque de collision si 2 IDs créés dans la même ms.

### Fuite mémoire
- **Blob URLs non révoqués** — ajout de `URL.revokeObjectURL()` pour les anciennes photos avant d'en charger de nouvelles. Les références aux vieux répertoires n'étaient jamais libérées.

### Version
- Bump 1.10.0 → 1.13.1

---

### Fichier ajouté
- `improvements.md` — catalogue des améliorations fonctionnelles et techniques futures (virtual scrolling, Web Worker, EXIF, i18n, etc.)